### PR TITLE
completer.complete throw error

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -82,10 +82,10 @@ Future<void> precacheImage(
   final Completer<void> completer = Completer<void>();
   final ImageStream stream = provider.resolve(config);
   void listener(ImageInfo image, bool sync) {
-    completer.complete();
+    if (!completer.isCompleted) completer.complete();
   }
   void errorListener(dynamic exception, StackTrace stackTrace) {
-    completer.complete();
+    if (!completer.isCompleted) completer.complete();
     if (onError != null) {
       onError(exception, stackTrace);
     } else {


### PR DESCRIPTION
completer.complete throw error because image is already loaded, i dont know if this is the right fix, but i think it's either this or there is some checking if the image is already loaded or not, if it's already loaded, then just return right away, otherwise, do the regular precache..